### PR TITLE
Release 1.0.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@
 ### Supported Versions
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.0   | :white_check_mark: |
-| < 0.3   | :x:                |
+| 1.0.0   | :white_check_mark: |
+| < 1.0   | :x:                |
 
 ### Reporting a Vulnerability
 Please direct all security related issues to [security@hypera.dev](mailto:security@hypera.dev).

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
-      <version>22.0.0</version>
+      <version>23.0.0</version>
     </dependency>
     <dependency>
       <groupId>me.lucko</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>dev.hypera</groupId>
   <artifactId>Dragonfly</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <name>Dragonfly</name>

--- a/src/main/java/dev/hypera/dragonfly/Dragonfly.java
+++ b/src/main/java/dev/hypera/dragonfly/Dragonfly.java
@@ -47,7 +47,7 @@ import org.jetbrains.annotations.ApiStatus.Internal;
  */
 public class Dragonfly {
 
-	private static final String VERSION = "0.3.0-SNAPSHOT";
+	private static final String VERSION = "1.0.0";
 
 	private final int timeout;
 	private final Path directory;


### PR DESCRIPTION
After having tested and used Dragonfly many times, I believe it is stable enough to release 1.0.0.
This pull request:
  - Bumps version to 1.0.0
  - Marks < 1.0 as not supported in SECURITY.md
  - Bumps annotations from 22.0.0 to 23.0.0, (#1)
  <br>
  
  Before this is merged, the following should be completed:
   - [ ] Create documentation